### PR TITLE
Check if cover image exist

### DIFF
--- a/appu.py
+++ b/appu.py
@@ -1,5 +1,5 @@
 from cli import get_logger, parse_config
-from audio import load_mp3, get_jingles, glue_tracks
+from audio import load_mp3, get_jingles, glue_tracks, check_cover
 
 logger = get_logger()
 cfg = parse_config()
@@ -33,7 +33,7 @@ final.export(
     bitrate='48000',
     parameters=["-ac", "1"],
     id3v2_version='3',
-    cover=cfg['cover_file'],
+    cover=check_cover(cfg['cover_file']),
 )
 
 logger.warning("Done! File {} generated correctly".format(cfg['final_file']))

--- a/appu.py
+++ b/appu.py
@@ -13,6 +13,8 @@ mp3_tags = {
     'comment': cfg['comment'],
 }
 
+check_cover(cfg['cover_file'])
+
 logger.warning("Importing podcast")
 podcast = load_mp3(cfg['podcast_file'], "podcast")
 
@@ -33,7 +35,7 @@ final.export(
     bitrate='48000',
     parameters=["-ac", "1"],
     id3v2_version='3',
-    cover=check_cover(cfg['cover_file']),
+    cover=cfg['cover_file'],
 )
 
 logger.warning("Done! File {} generated correctly".format(cfg['final_file']))

--- a/audio.py
+++ b/audio.py
@@ -1,5 +1,6 @@
 import re
 import requests
+import os.path
 from pydub import AudioSegment
 
 
@@ -31,6 +32,16 @@ def load_mp3(mp3_file_name, file_type='podcast'):
             'Incorrect audio file format. The file must have .mp3 extension'
         )
     return AudioSegment.from_mp3(mp3_file_name)
+
+def check_cover(cover_file):
+    """
+    Check if local cover file exist to avoid errors in transformation.
+    """
+    if not os.path.exists(cover_file):
+        raise SystemExit(
+            'Cover file not found.'
+        )
+    return cover_file
 
 
 def get_jingles(song_file_name):


### PR DESCRIPTION
If you set an incorrect file name to use it as a cover image, appu execution fails at the end. I set a check with a more descriptive error at the beginning of  the process.

Fixes #14 