### PR TITLE
Update system image in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: trusty
+dist: bionic
 sudo: required
 language: python
 python:


### PR DESCRIPTION
Besides we were using Trusty, being pretty old, Python 3.7 was not
supported for it. So, this change is updating Travis configuration to
use Bionic, which supports up to 3.8.


----

#