### PR TITLE
Adjust avconf/ffmpeg package name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 git:
   depth: 1
 before_script:
-  - sudo apt-get install libav-tools
+  - sudo apt-get install ffmpeg
   - pip install -r requirements.txt
 
 branches:


### PR DESCRIPTION
The libav-tools package is not available in Bionic. Its contents were
moved to the ffmpeg package.