### PR TITLE
Upload episode audio file to bucket

### DIFF
--- a/appu.py
+++ b/appu.py
@@ -14,19 +14,19 @@ mp3_tags = {
     'comment': cfg['comment'],
 }
 
-logger.warning("Importing podcast")
+logger.info("Importing podcast")
 podcast = load_mp3(cfg['podcast_file'], "podcast")
 
-logger.warning("Generating jingles")
+logger.info("Generating jingles")
 opening, ending = get_jingles(cfg['song_file'])
 
-logger.warning("Normalizing podcast audio")
+logger.info("Normalizing podcast audio")
 podcast = podcast.normalize()
 
-logger.warning("Generating final podcast file: opening + podcast + ending")
+logger.info("Generating final podcast file: opening + podcast + ending")
 final = glue_tracks([(opening, 0), (podcast, 1000), (ending, 4000)])
 
-logger.warning("Exporting final file")
+logger.info("Exporting final file")
 final.export(
     cfg['final_file'],
     format="mp3",
@@ -37,7 +37,7 @@ final.export(
     cover=cfg['cover_file'],
 )
 
-logger.warning("Done! File {} generated correctly".format(cfg['final_file']))
+logger.info("Done! File {} generated correctly".format(cfg['final_file']))
 
 if upload_file(cfg['final_file'], cfg['podcast_bucket']):
     logger.info("Episode uploaded to {}".format(cfg['podcast_bucket']))

--- a/appu.py
+++ b/appu.py
@@ -1,5 +1,6 @@
 from cli import get_logger, parse_config
 from audio import load_mp3, get_jingles, glue_tracks
+from publish import upload_file
 
 logger = get_logger()
 cfg = parse_config()
@@ -37,3 +38,6 @@ final.export(
 )
 
 logger.warning("Done! File {} generated correctly".format(cfg['final_file']))
+
+if upload_file(cfg['final_file'], cfg['podcast_bucket']):
+    logger.info("Episode uploaded to {}".format(cfg['podcast_bucket']))

--- a/config.cfg
+++ b/config.cfg
@@ -4,6 +4,7 @@ song_file=https://www.dropbox.com/s/18mxeanpr9jgxlp/intro.mp3?dl=0
 cover_file=files/logo.png
 
 final_file=podcast/edyo-55.mp3
+podcast_bucket=edyo-episodes
 
 [tag-config]
 

--- a/publish.py
+++ b/publish.py
@@ -1,0 +1,35 @@
+import logging
+import boto3
+from botocore.exceptions import ClientError
+
+
+def upload_file(file_name, bucket, object_name=None, s3_client=None):
+    """Upload a file to an S3 bucket
+
+    Arguments:
+    file_name (string): File to upload
+    bucket (string): Bucket to upload to
+    object_name (string): S3 object name. If not specified then file_name
+      is used
+    s3_client (boto3.session.Session.client): S3 client to use. If not
+      specified one is created. This is only useful for testing.
+
+    Returns:
+    boolean: True if file was uploaded, else False
+    """
+
+    # If no S3 client was specified, create a new one.
+    if s3_client is None:
+        s3_client = boto3.client('s3')
+
+    # If S3 object_name was not specified, use file_name.
+    if object_name is None:
+        object_name = file_name
+
+    # Upload the file, catching possible errors.
+    try:
+        response = s3_client.upload_file(file_name, bucket, object_name)
+    except ClientError as e:
+        logging.error(e)
+        return False
+    return True

--- a/tests/publish_test.py
+++ b/tests/publish_test.py
@@ -1,0 +1,38 @@
+import pytest
+from botocore.exceptions import ClientError
+
+from publish import upload_file
+
+
+class MockS3Client(object):
+    def upload_file(self, file_name, bucket, object_name):
+        if bucket == "private-bucket":
+            raise ClientError(
+                {'Error':
+                 {'Code': 'AccessDenied',
+                  'Message': 'Access Denied'}},
+                'PutObject',
+            )
+
+
+upload_file_cases = [
+    ("podcast/episode.mp3", "existing-bucket", "podcast/episode.mp3", True),
+    ("podcast/episode.mp3", "private-bucket", "podcast/episode.mp3", False),
+]
+
+
+@pytest.mark.parametrize(
+    "file_name, bucket, object_name, expected_result",
+    upload_file_cases,
+)
+def test_upload_file(
+        file_name,
+        bucket,
+        object_name,
+        expected_result,
+        caplog,
+):
+    result = upload_file(file_name, bucket, object_name, MockS3Client())
+    if not expected_result:
+        assert "rror" in caplog.text
+    assert result == expected_result


### PR DESCRIPTION
This will leave the file in our new bucket, so it's easier to get, and
not requiring any more commits into appu repository, once the current
publish procedure can stop using the committed episodes. This change
also includes tests for the new module.