### PR TITLE
Bumps from dependabot

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,7 @@ importlib-metadata==1.6.0 ; python_version < '3.8'
 more-itertools==8.3.0
 packaging==20.3
 pluggy==0.13.1
-py==1.8.1
+py==1.10.0
 pycodestyle==2.6.0
 pyparsing==2.4.7
 pytest==5.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ certifi==2020.4.5.1
 chardet==3.0.4
 idna==2.9
 pydub==0.24.0
-requests==2.23.0
-urllib3==1.25.9
-boto3==1.13.16
-botocore==1.16.16
+requests==2.26.0
+urllib3==1.26.5
+boto3==1.18.36
+botocore==1.21.36


### PR DESCRIPTION
When renaming master to main, the dependabot branches were mistakenly
removed. This applies the same changes:

* **Bump py 1.8.1 to 1.10.0**
* **Bump urllib3 from 1.25.9 to 1.26.5**