### PR TITLE
Containerize appu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.7-alpine
+
+RUN apk --update add \
+        ffmpeg \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm /var/cache/apk/*
+
+RUN addgroup -S appu -g 1000 \
+    && adduser -S appu -G appu -u 1000
+
+USER appu
+
+COPY --chown=appu:appu . /home/appu
+
+RUN mkdir -p /home/appu/files /home/appu/podcast
+
+RUN cd /home/appu/ \
+    && pip install -r requirements.txt
+
+WORKDIR /home/appu
+
+CMD ["/usr/local/bin/python", "/home/appu/appu.py"]

--- a/README.md
+++ b/README.md
@@ -1,38 +1,67 @@
-# APPU
-**A**utomatic **P**odcast **Pu**blisher
+# APPu
 
-Python tool used to automate the [EDyO](http://www.entredevyops.es) podcast publication.
+APPu, **A**utomatic **P**odcast **Pu**blisher, is a tool used to automate podcast episodes' publishing, as we do at the [EDyO](http://www.entredevyops.es) podcast.
 
-How it works
-------------
 
-* Clone the git repo
+## Description
 
-> ``` git clone https://github.com/dacacioa/appu.git ```
+This tool:
 
-* Put in the folder files:
+1. Downloads the media to edit the audio track: The master recording, and the intro and outro.
+2. Joins these tracks and normalizes the volume.
+3. Fills the ID3 tags, including the cover image, from provided information.
+4. Uploads the resulting audio track to the specified bucket.
 
-  * The main podcast audio files.
-  * The intro/ending music.
-  * The podcast's cover image.
+The information required is provided through a configuration file.
 
-** IMPORTANT: the files must be in mp3 format. **
+## Requirements
 
-* Modify config.cfg file setting:
+You'll need:
+* to have either [Docker](https://docs.docker.com/get-docker/), for Linux, Mac or Windows, installed, and
+* credentials to store the edited audio track in the publishing bucket.
 
-  * [files-config] section:
+## Usage
+### How to build it
 
-    * podcast_file --> The main podcast audio files (f.e files/main.mp3).
-    * song_file --> Intro/ending song file.
-    * cover_file --> The cover image file.
-    * final_file --> The final result file. It will be stored in podcast folder (f.e. podscat/EDyO-20.mp3).
+1. Clone the git repository and jump into it, 
+    ```
+    git clone https://github.com/EDyO/appu.git
+    cd appu
+    ```
+    
+    or jump into it and pull the latest changes:
+    ```
+    cd appu
+    git pull
+    ```
 
-  * [tag-config] section is the id3 metadata to add to the file. You have to set it without simple/double quotation marks.
+2. Build the image:
+    ```
+    docker build --pull --rm -f "Dockerfile" -t appu .
+    ```
 
-* Check if exist a travis-ci branch in github. If exist merge it with master or delete it.
-* Finally, you have to push into Github master repo branch.
+### How to use it
 
-> ``` git push https://github.com/dacacioa/appu.git origing/master ```
+1. Create your `config.cfg`:
 
-Then Travis CI will take the repo and will generate a new branch (travis-ci) with the final file set in the final_file param.
-You will can download it directly from Github.
+   This is an [INI](https://docs.python.org/3/library/configparser.html#supported-ini-file-structure) file, with the following sections and keys:
+   * In the `files-config`:
+     * `podcast_file`: A path or URL pointing to the master recording.
+     * `song_file`: A path or URL to the intro and outro jingles. The program will use the first second of the song as intro, and the last 4 seconds, as the outro.
+     * `cover_file`: A path to the image to use as cover in the resulting audio track.
+     * `final_file`: The bucket object ID.
+     * `podcast_bucket`: The name of the publishing bucket.
+   * In the `tag-config`:
+     * `title`: The title of the episode.
+     * `artist`: The name of the author/s.
+     * `album`: The name of the podcast.
+     * `track`: The number of this track.
+     * `year`: The year of the publishing.
+     * `comment`: The summary of the episode.
+
+2. Run the appu container. The following is an example of the run command in Linux:
+   ```
+   docker run --rm -v $(pwd)/yourconfig.cfg:/home/appu/config.cfg -v $(pwd)/bucket.credentials:/home/appu/.aws/credentials appu
+   ```
+   
+On completion, your episode should be present in the specified bucket.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,7 @@ importlib-metadata==1.6.0 ; python_version < '3.8'
 more-itertools==8.3.0
 packaging==20.3
 pluggy==0.13.1
-py==1.8.1
+py==1.10.0
 pycodestyle==2.6.0
 pyparsing==2.4.7
 pytest==5.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ certifi==2020.4.5.1
 chardet==3.0.4
 idna==2.9
 pydub==0.24.0
-requests==2.23.0
-urllib3==1.25.9
-boto3==1.13.16
-botocore==1.16.16
+requests==2.26.0
+urllib3==1.26.5
+boto3==1.18.36
+botocore==1.21.36


### PR DESCRIPTION
This should make easier to use appu in different platforms 
without having to recreate the Python environment. It also 
updates the README.md with the project details and 
instructions on how to build and use it.