### PR TITLE
Try to publish binaries with `gh release upload`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,10 +54,5 @@ jobs:
         run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
       - 
         name: Release built binaries
-        uses: xresloader/upload-to-github-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          file: build/*
-          tags: true
-          draft: false
+        run: |
+          gh release upload ${{ github.event.release.upload_url }} build/*


### PR DESCRIPTION
This [seems to be working for some people](https://github.com/actions/upload-release-asset/issues/69).