### PR TITLE
Update staticcheck-action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -127,7 +127,7 @@ jobs:
         with:
           go-version: "^1.16"
       - name: Install and run staticcheck
-        uses: dominikh/staticcheck-action@v1.2.0
+        uses: dominikh/staticcheck-action@v1.3.0
         with:
           version: "2022.1.1"
   check-license:


### PR DESCRIPTION
We need to update this as this external dependency's old version is
not using the right version of actions/cache.